### PR TITLE
[NEW] - Add option excludeOnFalseSchema + Test

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,7 +23,7 @@ enum SchemaTypes {
   Params = "params",
 }
 
-declare namespace fasticyEnforceSchema {
+declare namespace fastifyEnforceSchema {
   export type OriginFunction = (
     origin: string,
     callback: OriginCallback
@@ -35,6 +35,22 @@ declare namespace fasticyEnforceSchema {
      * A list of endpoints to exclude by the route path
      */
     exclude: string[];
+    /**
+     * If true, the plugin will not throw an error if the schema or schema types is equal to false
+     * @default false
+     * @example
+     * fastify.register(fastifyEnforceSchema, { excludeOnFalseSchema: true })
+     *
+     * fastify.get('/', { schema: false }, (req, reply) => {
+     *  reply.send({ hello: 'world' })
+     * })
+     * // or
+     * fastify.get('/test', { schema: { body: false } }, (req, reply) => {
+     *  reply.send({ hello: 'world' })
+     * })
+     * // no error will be thrown
+     */
+    excludeOnFalseSchema: boolean;
   }
 
   export interface FastifyEnforceSchemaOptionsDelegateCallback {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fastify-enforce-schema",
   "url": "",
   "author": "Aleksandar Grbic - (https://programmer.network)",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Enforce AJV schemas across your endpoints.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR will make it possible to write: 
```js
{schema: false}
```
or
```js
{schema: {response: false}}
```
To exclude either the whole endpoint or just e.g. `response` if plugin option: `excludeOnFalseSchema = true`

Also added some tests for the cases and to raise coverage:
![image](https://user-images.githubusercontent.com/116656856/206597539-cb2a4b69-222e-4a40-8683-85cc339aad34.png)
